### PR TITLE
adapted table structure and metadata #7

### DIFF
--- a/database_adapter/reeem_adapter_ecosense.py
+++ b/database_adapter/reeem_adapter_ecosense.py
@@ -1,0 +1,97 @@
+"""read data from file and write to database"""
+
+__copyright__ = "© Reiner Lemoine Institut"
+__license__ = "GNU Affero General Public License Version 3 (AGPL-3.0)"
+__url__ = "https://www.gnu.org/licenses/agpl-3.0.en.html"
+__author__ = "Ludwig Hülk"
+__issue__ = "https://github.com/ReeemProject/reeem_db/issues/32"
+__version__ = "v0.1.3"
+
+from reeem_io import *
+
+# input
+filename = "2018-06-07_BASE_EcoSense_FrameworkV1_DataV3_Output.csv"
+
+empty_rows = 1
+
+#file
+#file_name_input = 'REEEM_Ecosense_Input.csv'
+#file_name_output = 'REEEM_Ecosense_Output.csv'
+
+# database table
+db_schema = 'model_draft' 
+#db_table_input = 'reeem_ecosenseeva_input' 
+db_table_output = 'reeem_ecosense_output'
+
+## functions
+def ecosense_2_reeem_db(filename, fns, db_table, empty_rows, db_schema, con):
+    """read csv file, make dataframe and write to database"""
+
+    # read file
+    csv = os.path.join('Model_Data', 'EcoSense', filename)
+    df = pd.read_csv(csv, sep=';')
+
+    # make dataframe
+    df.columns = ['nid', 'category', 'region', 'region_2' 'year', 'indicator', 'value',
+                  'unit', 'aggregation', 'source']
+    df.index.names = ['id']
+    dfdb = df.drop(
+        ['source'],
+        axis=1).dropna()
+
+
+    dfdb['pathway'] = fns['pathway']
+    dfdb['framework'] = fns['framework']
+    dfdb['version'] = fns['version']
+    dfdb['updated'] = fns['day']
+    
+
+    # copy dataframe to database
+    dfdb.to_sql(con=con,
+                schema=db_schema,
+                name=db_table,
+                if_exists='append',
+                index=True)
+    log.info('......table sucessfully imported...')
+
+
+if __name__ == '__main__':
+    # file and table
+    fns = reeem_filenamesplit(filename)
+
+    # i/o
+    if fns['io'] == "Input":
+        db_table = db_table_input
+    else:
+        db_table = db_table_output
+
+    # logging
+    log = logger()
+    start_time = time.time()
+    log.info('script started...')
+    log.info('...file: {}'.format(filename))
+    log.info('...pathway: {}'.format(fns['pathway']))
+    log.info('...model: {}'.format(fns['model']))
+    log.info('...framework: {}'.format(fns['framework']))
+    log.info('...version: {}'.format(fns['version']))
+    log.info('...i/o: {}'.format(fns['io']))
+    #log.info('...regions: {}'.format(regions))
+    log.info('...database table: model_draft.{}'.format(db_table))
+    log.info('...establish database connection...')
+
+    # connection
+    con = reeem_session()
+    log.info('...read file(s)...')
+
+    # import
+    ecosense_2_reeem_db(filename, fns, db_table, empty_rows, db_schema, con)
+
+    # scenario log
+    scenario_log(con, 'REEEM', __version__, 'import', db_schema, db_table,
+                 os.path.basename(__file__), filename)
+
+    # close connection
+    con.close()
+    log.info('...script successfully executed in {:.2f} seconds...'
+             .format(time.time() - start_time))
+    log.info('...database connection closed. Goodbye!')

--- a/database_setup/reeem_db_setup_ecosense.sql
+++ b/database_setup/reeem_db_setup_ecosense.sql
@@ -6,10 +6,10 @@ EcoSense Output
 
 https://github.com/ReeemProject/reeem_db/issues/7
 
-__copyright__   = "© Reiner Lemoine Institut"
+__copyright__   = "ï¿½ Reiner Lemoine Institut"
 __license__     = "GNU Affero General Public License Version 3 (AGPL-3.0)"
 __url__         = "https://www.gnu.org/licenses/agpl-3.0.en.html"
-__author__      = "Ludwig Hülk"
+__author__      = "Ludwig Hï¿½lk"
 */
 
 /*
@@ -91,14 +91,15 @@ SELECT reeem_scenario_log('v0.1.0','setup','model_draft','reeem_emc2_input','ree
 
 
 -- EcoSense Output
-DROP TABLE IF EXISTS    model_draft.reeem_ecosenseeva_output CASCADE;
-CREATE TABLE            model_draft.reeem_ecosenseeva_output (
+DROP TABLE IF EXISTS    model_draft.reeem_ecosense_output CASCADE;
+CREATE TABLE            model_draft.reeem_ecosense_output (
     "id"            serial NOT NULL,
     "nid"           integer,
     "pathway"       text,
     "framework"     text,
     "version"       text,
     "region"        text,
+    "region_2"      text,
     "year"          smallint,
     "category"      text,
     "indicator"     text,
@@ -107,7 +108,7 @@ CREATE TABLE            model_draft.reeem_ecosenseeva_output (
     "aggregation"   boolean,
     "tags"          hstore,
     "updated"       timestamp with time zone,
-    CONSTRAINT reeem_ecosenseeva_output_pkey PRIMARY KEY (id) );
+    CONSTRAINT reeem_ecosense_output_pkey PRIMARY KEY (id) );
 
 -- access rights
 ALTER TABLE             model_draft.reeem_ecosenseeva_output OWNER TO reeem_user;
@@ -126,23 +127,24 @@ COMMENT ON TABLE model_draft.reeem_ecosenseeva_output IS
         {"reference_date": "2010",
         "start": "2015",
         "end": "2050",
-        "resolution": "10 years"},
+        "resolution": "5 years"},
     "sources": [
-        {"name": "", "description": "", "url": "", "license": "", "copyright": ""},
+        {"name": "TIMES PanEU emisison data", "description": "uses emission data from TIMES PanEU results for respective pahtways, framework and data version", "url": "none", "license": "none", "copyright": "none"},
         {"name": "", "description": "", "url": "", "license": "", "copyright": ""} ],
     "license":
-        {"id": "tba",
-        "name": "tba",
-        "version": "tba",
-        "url": "tba",
-        "instruction": "tba",
-        "copyright": "tba"},
+        {"id": "ODC-BY-1.0",
+        "name": "Open Data Commons Attribution License 1.0",
+        "version": "1.0",
+        "url": "http://opendatacommons.org/licenses/by",
+        "instruction": "You are free: To Share, To Create, To Adapt; As long as you: Attribute!",
+        "copyright": ""Â© Institut fÃ¼r Energiewirtschaft und Rationelle Energieanwendung (IER) der UniversitÃ¤t Stuttgart"},
     "contributors": [
         {"name": "Ludee", "email": "none", "date": "2017-05-09", "comment": "Create table"},
         {"name": "Ludee", "email": "none", "date": "2017-11-08", "comment": "Update structure and metadata"},
-        {"name": "Ludee", "email": "none", "date": "2018-04-12", "comment": "Finalize structure and update metadata"} ],
+        {"name": "Ludee", "email": "none", "date": "2018-04-12", "comment": "Finalize structure and update metadata"} 
+        {"name": "doroschmid", "email": "none", "date": 2018-06-07". "comment": "Update structure and metada"}],
     "resources": [
-        {"name": "model_draft.reeem_ecosenseeva_output",
+        {"name": "model_draft.reeem_ecosense_output",
         "format": "PostgreSQL",
         "fields": [
             {"name": "id", "description": "Unique identifier", "unit": "none"},
@@ -150,7 +152,8 @@ COMMENT ON TABLE model_draft.reeem_ecosenseeva_output IS
             {"name": "pathway", "description": "REEEM pathway", "unit": "none"},
             {"name": "framework", "description": "REEEM framework", "unit": "none"},
             {"name": "version", "description": "REEEM version", "unit": "none"},
-            {"name": "region", "description": "Country or region", "unit": "none"},
+            {"name": "region", "description": "Country (responsible for impacts)", "unit": "none"},
+            {"name": "region_2", "description": "Country (where impacts occur)", "unit": "none"},
             {"name": "year", "description": "Year", "unit": "none"},
             {"name": "category", "description": "2. classification", "unit": "none"},
             {"name": "indicator", "description": "Parameter name", "unit": "none"},
@@ -162,4 +165,4 @@ COMMENT ON TABLE model_draft.reeem_ecosenseeva_output IS
     "metadata_version": "1.3"}';
 
 -- scenario log (version,io,schema_name,table_name,script_name,comment)
-SELECT scenario_log('REEEM','v0.1.0','setup','model_draft','reeem_ecosenseeva_output','reeem_db_setup_ecosense.sql',' ');
+SELECT scenario_log('REEEM','v0.1.0','setup','model_draft','reeem_ecosense_output','reeem_db_setup_ecosense.sql',' ');


### PR DESCRIPTION
Hej Ludwig,

I changed the table structure for impacts based on TIMES PanEU data as EcoSense output, icluding adding all metadata (at least I hope so).
Instead of re-uploading TIMES PanEU emission data as EcoSense input, I referenced this under 'source' in the metadata.

I included an additional column 'region_2' which contains the country in which the impacts occur (while region is the country responsible for the impacts). Hope this is okay and the description in the metadata captures this.
Costs are not separated for region_2 (because they are attributable to the responsible country). Here I just left the column empty.

I also tried to change the EcoSense adapter accordingly, hope it is correct.

Please review both reem_db_setup_ecosense.sql and reeem_adapter_ecosense.py
If you give your okay (and set up the table with the new structure) I'll upload the data to the database (it is already on sharepoint).